### PR TITLE
Added History and fixed some cases with favorites

### DIFF
--- a/src/app/services/[service_info]/page.js
+++ b/src/app/services/[service_info]/page.js
@@ -18,28 +18,23 @@ export default function ServiceInfo(){
 
     const [isScriptLoaded, setIsScriptLoaded] = useState(false);
     const router = useRouter();
+    const [addServices, setYes] = useState(false)
 
     const handleBack = ()=>{
         setBack(true);
     }
 
     //checks to see if user reaches decided limit
-    const handleEnter = ()=> {
-        router.push(numberPlaces == userServices.length ? "/end": "/questionaire")
+    const handleEnter = ()=> { 
+        if (numberPlaces == userServices.length)
+            setYes(true);
+        else
+            router.push("/questionaire") //checks to see if user reaches decided limit
     }
     useEffect(() => {
         const handleRouteChangeComplete = async () => {
 
-            if (numberPlaces == userServices.length && !moreThan1)
-            {
-                const addressArr = [];
-                userServices.forEach(element => {
-                    addService(element.formattedAddress, element);
-                    addressArr.push(element.formattedAddress);
-                });
-                addHistoryService(addressArr, userEmail[1]);
-                setMoreThan1(true);
-            }
+
 
             if ((window.history.state && window.history.state.navigationDirection == "back") || wentBack)
                 setServices(userServices.slice(0, userServices.length -1)); //goal is to remove current services from list of services that user selects
@@ -48,8 +43,27 @@ export default function ServiceInfo(){
                 router.back(); //should be the services menu page since you can only reach this page by clicking a service in services menu
             }
         };
-        handleRouteChangeComplete();
-    }, [wentBack]
+
+        const handleAdd = async () => {
+            if (numberPlaces == userServices.length && !moreThan1)
+                {
+                    const addressArr = [];
+                    userServices.forEach(element => {
+                        addService(element.formattedAddress, element);
+                        addressArr.push(element.formattedAddress);
+                    });
+                    await addHistoryService(addressArr, userEmail[1]);
+                    setMoreThan1(true);
+                }
+            router.push("/end");
+        }
+
+        if (!addServices)
+            handleRouteChangeComplete();
+        else 
+            handleAdd();
+
+    }, [wentBack, addServices]
     );
 
     return(

--- a/src/app/services/[service_info]/page.js
+++ b/src/app/services/[service_info]/page.js
@@ -4,14 +4,17 @@ import "../../css/services_page.css"
 import { useAppContext } from "@/context";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import { addService, addHistoryService } from '@/components/DBactions';
 import GenericSingleMap from "@/components/GenericSingleMap";
 import Script from "next/script";
+import { users } from "@/db/schema/users";
 
 
 
 export default function ServiceInfo(){
-    const {userServices, setServices, numberPlaces} = useAppContext();
-    const [wentBack, setBack] = useState(false); //used to check when the user leaves page in regards to our UI, not back arrow from browser 
+    const {userServices, setServices, numberPlaces, userEmail} = useAppContext();
+    const [wentBack, setBack] = useState(false); //used to check when the user leaves page in regards to our UI, not back arrow from browser
+    const [moreThan1, setMoreThan1] = useState(false);
 
     const [isScriptLoaded, setIsScriptLoaded] = useState(false);
     const router = useRouter();
@@ -20,11 +23,24 @@ export default function ServiceInfo(){
         setBack(true);
     }
 
-    const handleEnter = ()=> { 
-        router.push(numberPlaces == userServices.length ? "/end": "/questionaire") //checks to see if user reaches decided limit
+    //checks to see if user reaches decided limit
+    const handleEnter = ()=> {
+        router.push(numberPlaces == userServices.length ? "/end": "/questionaire")
     }
     useEffect(() => {
-        const handleRouteChangeComplete = () => {
+        const handleRouteChangeComplete = async () => {
+
+            if (numberPlaces == userServices.length && !moreThan1)
+            {
+                const addressArr = [];
+                userServices.forEach(element => {
+                    addService(element.formattedAddress, element);
+                    addressArr.push(element.formattedAddress);
+                });
+                addHistoryService(addressArr, userEmail[1]);
+                setMoreThan1(true);
+            }
+
             if ((window.history.state && window.history.state.navigationDirection == "back") || wentBack)
                 setServices(userServices.slice(0, userServices.length -1)); //goal is to remove current services from list of services that user selects
             if (wentBack){

--- a/src/components/DBactions.js
+++ b/src/components/DBactions.js
@@ -1,13 +1,15 @@
 "use server";
 import { db } from "../db/index.js";
 import { users } from "../db/schema/users.js";
-import { eq, and} from "drizzle-orm";
+import { eq, and, sql} from "drizzle-orm";
 
 import { userAgentFromString } from "next/server.js";
 import { questions } from "../db/schema/questions.js";
 import { services } from "../db/schema/services.js";
 import { favorites } from "../db/schema/favorites.js";
+import { history } from "../db/schema/history.js";
 import bcrypt from "bcryptjs";
+import { Truculenta } from "next/font/google/index.js";
 
 // testing for existing emails in singup
 export async function testExistingUser(email){
@@ -145,6 +147,62 @@ export async function getUser(email) {
 
 
 
+ export async function checkService(primaryKey) {
+  const data = await db.select().from(services).where(eq(services.address, primaryKey));
+  return data.length === 0;
+ }
+
+ export async function checkFavoriteService(primaryKey, email){
+  const data = await db.select().from(favorites).where(and(eq(favorites.sAddress, primaryKey), eq(favorites.userEmail, email)));
+  return data.length === 0;
+ }
+
+ export async function checkHistoryService(primaryKey, email, d2) {
+  const data = await db.select({time: sql`time(created_at)`, date: sql`date(created_at)`}).from(history).where(and(eq(history.sAddress, primaryKey), eq(history.userEmail, email)));
+  if (data.length == 0){
+    return true
+  }
+  else{
+    data.forEach(element => {
+      if(d2[0].date == element.date)
+      {
+        let [h1, m1, s1] = element.time.split(':');
+        let [h2, m2, s2] =  d2[0].time.split(':');
+        let val1 = ((h1*60)*60) + (m1*60) + s1;
+        let val2 = ((h2*60)*60) + (m2*60) + s2;    
+
+        difference = val1 - val2;
+        if (difference <= 10)
+          return false;
+      }
+    });
+    return true;
+  }
+ }
+
+
+ export async function addService(primaryKey, info) {
+    try {
+    console.log("adding service to db:", {
+      primaryKey,
+      info,
+    });
+
+    if(await checkService(primaryKey)){
+      await db.insert(services).values({
+        address: primaryKey,
+        info: JSON.stringify(info),
+      });
+    }
+
+  } catch (e) {
+    console.error("error in in service adding:", e);
+    throw e;
+  }
+ }
+
+
+
  export async function addFavoriteService(primaryKey, info, email) {
   try {
     console.log("adding service to db:", {
@@ -152,11 +210,12 @@ export async function getUser(email) {
       info,
     });
 
-
-    await db.insert(services).values({
-      address: primaryKey,
-      info: JSON.stringify(info),
-    });
+    if(await checkService(primaryKey)){
+      await db.insert(services).values({
+        address: primaryKey,
+        info: JSON.stringify(info),
+      });
+    }
     await db.insert(favorites).values({
       userEmail: email,
       sAddress:  primaryKey,
@@ -167,13 +226,6 @@ export async function getUser(email) {
   }
  }
 
- export async function checkService(primaryKey){
-  const data = await db.select().from(services).where(eq(services.address, primaryKey));
-  return data.length === 0;
- }
-
-
-
  export async function removeFavoriteService(primaryKey, email) {
   try {
     console.log("deleting service to db:", {
@@ -181,9 +233,29 @@ export async function getUser(email) {
     });
 
     await db.delete(favorites).where(and(eq(favorites.sAddress, primaryKey), eq(favorites.userEmail, email)));
-    await db.delete(services).where(eq(services.address, primaryKey));
   } catch (e) {
     console.error("error in in service deletion:", e);
+    throw e;
+  }
+ }
+
+
+ export async function addHistoryService(services, email) {
+  try {
+    console.log("adding service to db:", {
+      services,
+      email,
+    });
+    const d2 = await db.select({total: sql`(CURRENT_TIMESTAMP)`, time: sql`time(CURRENT_TIMESTAMP)`, date: sql`date(CURRENT_TIMESTAMP)`}).from(users).where(eq(users.email, email));
+    if(await checkHistoryService(services, email, d2)) {
+    await db.insert(history).values({
+      userEmail: email,
+      sAddress:  JSON.stringify(services),
+      createdAt: d2.total,
+    })
+  }
+  } catch (e) {
+    console.error("error in in service adding:", e);
     throw e;
   }
  }

--- a/src/components/Favorites.js
+++ b/src/components/Favorites.js
@@ -1,6 +1,6 @@
 "use client"
 import { useEffect, useState } from "react";
-import { addFavoriteService, checkService, removeFavoriteService } from "./DBactions";
+import { addFavoriteService, checkFavoriteService, removeFavoriteService } from "./DBactions";
 import { useAppContext } from "@/context";
 
 
@@ -16,32 +16,34 @@ function Favorites({service}){
     {
         setStar(!star);
         
-        checkService(service.formattedAddress).then((data) => {
+        checkFavoriteService(service.formattedAddress, sVal).then((data) => {
           if (data)
             addFavoriteService(info.formattedAddress, info, sVal);
         });
 
         if (!star)
         {
-            checkService(service.formattedAddress).then((data) => {
+            checkFavoriteService(service.formattedAddress, sVal).then((data) => {
                 if (!data)
                     removeFavoriteService(info.formattedAddress, sVal);
             });
         }
     }
 
+    /*
     function initialStar()
     {
-        checkService(service.formattedAddress).then((data) => {
+        checkFavoriteService(service.formattedAddress, sVal).then((data) => {
             if (!data)
                 setStar(false);
           });
     }
+          */
 
     useEffect(() => {
         const fetchProducts = async () => {
             try{
-                if(!(await checkService(info.formattedAddress)))
+                if(!(await checkFavoriteService(service.formattedAddress, sVal)))
                     setStar(false);
             } catch(error) {
                 console.error("Error fetching DB:", error);

--- a/src/db/migrations/0003_redundant_sharon_carter.sql
+++ b/src/db/migrations/0003_redundant_sharon_carter.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `favorites` (
+	`userEmail` text NOT NULL,
+	`sAddress` text NOT NULL,
+	PRIMARY KEY(`userEmail`, `sAddress`),
+	FOREIGN KEY (`userEmail`) REFERENCES `users`(`email`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`sAddress`) REFERENCES `services`(`address`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `history` (
+	`userEmail` text NOT NULL,
+	`sAddress` text NOT NULL,
+	PRIMARY KEY(`userEmail`, `sAddress`),
+	FOREIGN KEY (`userEmail`) REFERENCES `users`(`email`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`sAddress`) REFERENCES `services`(`address`) ON UPDATE no action ON DELETE no action
+);

--- a/src/db/migrations/0004_real_menace.sql
+++ b/src/db/migrations/0004_real_menace.sql
@@ -1,0 +1,13 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_history` (
+	`userEmail` text NOT NULL,
+	`sAddress` text NOT NULL,
+	`created_at` integer DEFAULT (CURRENT_TIMESTAMP),
+	PRIMARY KEY(`userEmail`, `sAddress`, `created_at`),
+	FOREIGN KEY (`userEmail`) REFERENCES `users`(`email`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_history`("userEmail", "sAddress", "created_at") SELECT "userEmail", "sAddress", "created_at" FROM `history`;--> statement-breakpoint
+DROP TABLE `history`;--> statement-breakpoint
+ALTER TABLE `__new_history` RENAME TO `history`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/src/db/migrations/meta/0003_snapshot.json
+++ b/src/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,335 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "58319012-3225-4c63-87e5-9ebf1ec9418a",
+  "prevId": "806f7341-2915-4b94-b791-f55ad567561b",
+  "tables": {
+    "addresses": {
+      "name": "addresses",
+      "columns": {
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "addresses_user_email_users_email_fk": {
+          "name": "addresses_user_email_users_email_fk",
+          "tableFrom": "addresses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_email"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "favorites": {
+      "name": "favorites",
+      "columns": {
+        "userEmail": {
+          "name": "userEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sAddress": {
+          "name": "sAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorites_userEmail_users_email_fk": {
+          "name": "favorites_userEmail_users_email_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userEmail"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "favorites_sAddress_services_address_fk": {
+          "name": "favorites_sAddress_services_address_fk",
+          "tableFrom": "favorites",
+          "tableTo": "services",
+          "columnsFrom": [
+            "sAddress"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorites_userEmail_sAddress_pk": {
+          "columns": [
+            "userEmail",
+            "sAddress"
+          ],
+          "name": "favorites_userEmail_sAddress_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "history": {
+      "name": "history",
+      "columns": {
+        "userEmail": {
+          "name": "userEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sAddress": {
+          "name": "sAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "history_userEmail_users_email_fk": {
+          "name": "history_userEmail_users_email_fk",
+          "tableFrom": "history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userEmail"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "history_sAddress_services_address_fk": {
+          "name": "history_sAddress_services_address_fk",
+          "tableFrom": "history",
+          "tableTo": "services",
+          "columnsFrom": [
+            "sAddress"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "history_userEmail_sAddress_pk": {
+          "columns": [
+            "userEmail",
+            "sAddress"
+          ],
+          "name": "history_userEmail_sAddress_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_user_email_users_email_fk": {
+          "name": "questions_user_email_users_email_fk",
+          "tableFrom": "questions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_email"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "services": {
+      "name": "services",
+      "columns": {
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "info": {
+          "name": "info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/0004_snapshot.json
+++ b/src/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,331 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5e75a2b7-8e95-41ce-a6e3-169831841d1a",
+  "prevId": "58319012-3225-4c63-87e5-9ebf1ec9418a",
+  "tables": {
+    "addresses": {
+      "name": "addresses",
+      "columns": {
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "addresses_user_email_users_email_fk": {
+          "name": "addresses_user_email_users_email_fk",
+          "tableFrom": "addresses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_email"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "favorites": {
+      "name": "favorites",
+      "columns": {
+        "userEmail": {
+          "name": "userEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sAddress": {
+          "name": "sAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorites_userEmail_users_email_fk": {
+          "name": "favorites_userEmail_users_email_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userEmail"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "favorites_sAddress_services_address_fk": {
+          "name": "favorites_sAddress_services_address_fk",
+          "tableFrom": "favorites",
+          "tableTo": "services",
+          "columnsFrom": [
+            "sAddress"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorites_userEmail_sAddress_pk": {
+          "columns": [
+            "userEmail",
+            "sAddress"
+          ],
+          "name": "favorites_userEmail_sAddress_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "history": {
+      "name": "history",
+      "columns": {
+        "userEmail": {
+          "name": "userEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sAddress": {
+          "name": "sAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "history_userEmail_users_email_fk": {
+          "name": "history_userEmail_users_email_fk",
+          "tableFrom": "history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userEmail"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "history_userEmail_sAddress_created_at_pk": {
+          "columns": [
+            "userEmail",
+            "sAddress",
+            "created_at"
+          ],
+          "name": "history_userEmail_sAddress_created_at_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_user_email_users_email_fk": {
+          "name": "questions_user_email_users_email_fk",
+          "tableFrom": "questions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_email"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "services": {
+      "name": "services",
+      "columns": {
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "info": {
+          "name": "info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -22,6 +22,20 @@
       "when": 1741537826248,
       "tag": "0002_solid_war_machine",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1741678699671,
+      "tag": "0003_redundant_sharon_carter",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1741682025873,
+      "tag": "0004_real_menace",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/history.js
+++ b/src/db/schema/history.js
@@ -1,0 +1,16 @@
+// Favorites(userEmail: String, ServiceAddress: String)
+import { sql, Table } from "drizzle-orm";
+import { text, primaryKey, sqliteTable, integer} from "drizzle-orm/sqlite-core";
+import { users } from "./users.js"; // reference to users table
+import { services } from "./services.js"; // reference to services table
+
+export const history = sqliteTable("history", {
+    userEmail: text("userEmail").notNull().references(() => users.email),
+    sAddress: text('sAddress', { mode: 'json' })
+    .notNull()
+    .$default(sql`'[]'`),
+    createdAt: integer("created_at").default(sql`(CURRENT_TIMESTAMP)`),
+
+}, (table) => [
+    primaryKey({columns: [table.userEmail, table.sAddress, table.createdAt]}),
+]);

--- a/src/db/testing.js
+++ b/src/db/testing.js
@@ -1,8 +1,8 @@
 
 import { db } from "./index.js";
 import { users } from "./schema/users.js";
-import { eq } from "drizzle-orm";
-import { addUser, checkLogin, testExistingUser, getUser, addService, removeService, checkService} from '../components/DBactions.js'
+import { eq, sql } from "drizzle-orm";
+import { addUser, checkLogin, testExistingUser, getUser} from '../components/DBactions.js'
 // import { addUser, testExistingUser } from "@/components/DBactions.js";
 import bcrypt from "bcrypt"
 import { getModifiedCookieValues } from "next/dist/server/web/spec-extension/adapters/request-cookies.js";
@@ -52,13 +52,58 @@ const test = await db.select({email: users.email}).from(users).where(eq(users.em
 
 //removeService("test email");
 
+/*
+const values =  await db
+.select({
+    time: sql`time(created_at)` 
+})
+.from(users);
 
-        checkService("test email").then((data) => {
-          if (data)
-            addService("test email", "TEST:tewewfeww");
-        });
+const val2 = await db
+.select({
+    time: sql`time(CURRENT_TIMESTAMP)`
+})
+.from(users)
+.where(eq(users.email, 'gaelg@gmail.com'));
 
-        checkService("test email").then((data) => {
-            if (!data)
-                removeService("test email");
-          });
+let [hour1, min1, sec1] = val2[0].time.split(':')
+let [hour2, min2, sec2] =  values[0].time.split(':')
+
+const difference = sec1 - sec2;
+
+if(difference >= 30)
+{
+    console.log("its greater")
+}
+else
+{
+    console.log("it isnt")
+}
+console.log(values[0].time);
+console.log(val2[0].time);
+console.log(difference)
+
+
+*/
+
+  //eq(history.createdAt, sql`(CURRENT_TIMESTAMP)`)
+  const data = await db.select({time: sql`time(created_at)`, date: sql`date(created_at)`}).from(users);
+  const d1 = await db.select({time: sql`time(CURRENT_TIMESTAMP)`, date: sql`date(CURRENT_TIMESTAMP)`}).from(users).where(eq(users.email, 'test@gmail.com'));
+  const d2 = await db.select({time: sql`time(CURRENT_TIMESTAMP)`, date: sql`date(CURRENT_TIMESTAMP)`}).from(users).where(eq(users.email, 'test@gmail.com'));
+  console.log(data);
+  console.log(d2);
+  
+  data.forEach(element => {
+    let [h1, m1, s1] = d1[0].time.split(':');
+    let [h2, m2, s2] =  d2[0].time.split(':');
+    let val1 = (m2*60) + s2;
+    let val2 = (m1*60) + s1;
+    let difference = val2-val1;
+    if(d1[0].date == d2[0].date)
+        console.log("IT WORKS")
+    console.log(val1)
+    console.log(val2);
+    console.log(difference)
+  });
+
+


### PR DESCRIPTION
1. So now a history of services given the final service screen is added to the DB

I haven't yet added it to the UI, making it take much longer than I initially thought. Given that I had to make created at a part of the primary keys, testing for that was pretty difficult.
There are still some SQL errors that sometimes happen where it's unable to add a unique key, but at least that means its not adding duplicates, so although its an error, it should be fine. 

For some reason, it runs the code twice, I imagine it being due to the fact that it runs onclick and before click to route. I couldn't add the code specifically onto the route function because it didn't allow for the await to process properly, so I had to add it to the useEffect.

Maybe there is a better method for doing it, but this works. 